### PR TITLE
[issue#249] renderer crash on syntax error

### DIFF
--- a/src/main/kotlin/de/timo_reymann/mjml_support/editor/render/MjmlRenderResultError.kt
+++ b/src/main/kotlin/de/timo_reymann/mjml_support/editor/render/MjmlRenderResultError.kt
@@ -6,6 +6,8 @@ class MjmlRenderResultError {
     var tagName: String? = null
     var formattedMessage: String? = null
 
+    constructor(){ }
+
     constructor(message: String) {
         this.message = message
     }

--- a/src/main/kotlin/de/timo_reymann/mjml_support/editor/render/MjmlRenderer.kt
+++ b/src/main/kotlin/de/timo_reymann/mjml_support/editor/render/MjmlRenderer.kt
@@ -1,5 +1,6 @@
 package de.timo_reymann.mjml_support.editor.render
 
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.OSProcessHandler
@@ -38,6 +39,10 @@ class MjmlRenderer(
     private val objectMapper = jacksonObjectMapper()
     private val basePath by lazy {
         File(virtualFile.path).parentFile
+    }
+
+    init {
+        objectMapper.registerModules(KotlinModule.Builder().build())
     }
 
     private val postProcessor = MjmlPostProcessor(basePath, mjmlSettings)
@@ -87,7 +92,7 @@ class MjmlRenderer(
         val mapper = jacksonObjectMapper()
         var renderResult: MjmlRenderResult
         try {
-            renderResult = mapper.readValue(rawJson, MjmlRenderResult::class.java)
+            renderResult = objectMapper.readValue(rawJson, MjmlRenderResult::class.java)
         } catch (e: Throwable) {
             getLogger<MjmlRenderer>().warn {
                 MjmlBundle.message("mjml_preview.render_parsing_failed", rawJson) + e.stackTraceToString()


### PR DESCRIPTION
Fix 

> "com.fasterxml.jackson.databind.exc.MismatchedInputE…xception: Cannot construct instance of `de.timo_reymann.mjml_support.editor.render.MjmlRenderResultError` (although at least one Creator exists): cannot deserialize from Object value (no delegate- or property-based Creator)" error in jackson by


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Resolves #249

## Description
- adding a default constructor in  MjmlRenderResultError, and 
- registering the Kotlin Module builder with the objectMapper before use (see https://stackoverflow.com/questions/55529028)


