### PR TITLE
Resolve plugin verifier API findings + default to MJML v5

### DIFF
--- a/src/main/kotlin/de/timo_reymann/mjml_support/editor/provider/SplitTextEditorProvider.kt
+++ b/src/main/kotlin/de/timo_reymann/mjml_support/editor/provider/SplitTextEditorProvider.kt
@@ -9,7 +9,7 @@ import org.jdom.Element
 
 abstract class SplitTextEditorProvider(
     private val myFirstProvider: FileEditorProvider, private val mySecondProvider: FileEditorProvider
-) : AsyncFileEditorProvider, DumbAware {
+) : FileEditorProvider, DumbAware {
     private val myEditorTypeId: String =
         "split-provider[" + myFirstProvider.editorTypeId + ";" + mySecondProvider.editorTypeId + "]"
 
@@ -17,19 +17,12 @@ abstract class SplitTextEditorProvider(
         myFirstProvider.accept(project, file) && mySecondProvider.accept(project, file)
 
     override fun createEditor(project: Project, file: VirtualFile): FileEditor =
-        createEditorAsync(project, file).build()
+        createSplitEditor(
+            myFirstProvider.createEditor(project, file),
+            mySecondProvider.createEditor(project, file)
+        )
 
     override fun getEditorTypeId(): String = myEditorTypeId
-
-    override fun createEditorAsync(project: Project, file: VirtualFile): AsyncFileEditorProvider.Builder {
-        val firstBuilder = getBuilderFromEditorProvider(myFirstProvider, project, file)
-        val secondBuilder = getBuilderFromEditorProvider(mySecondProvider, project, file)
-        return object : AsyncFileEditorProvider.Builder() {
-            override fun build(): FileEditor {
-                return createSplitEditor(firstBuilder.build(), secondBuilder.build())
-            }
-        }
-    }
 
     override fun readState(sourceElement: Element, project: Project, file: VirtualFile): FileEditorState {
         var child = sourceElement.getChild(FIRST_EDITOR)
@@ -85,15 +78,5 @@ abstract class SplitTextEditorProvider(
         private const val FIRST_EDITOR = "first_editor"
         private const val SECOND_EDITOR = "second_editor"
         private const val SPLIT_LAYOUT = "split_layout"
-
-        fun getBuilderFromEditorProvider(
-            provider: FileEditorProvider, project: Project, file: VirtualFile
-        ): AsyncFileEditorProvider.Builder {
-            return object : AsyncFileEditorProvider.Builder() {
-                override fun build(): FileEditor {
-                    return provider.createEditor(project, file)
-                }
-            }
-        }
     }
 }

--- a/src/main/kotlin/de/timo_reymann/mjml_support/editor/rendering/MjmlRendererService.kt
+++ b/src/main/kotlin/de/timo_reymann/mjml_support/editor/rendering/MjmlRendererService.kt
@@ -1,6 +1,6 @@
 package de.timo_reymann.mjml_support.editor.rendering
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
@@ -13,8 +13,9 @@ import de.timo_reymann.mjml_support.settings.MjmlSettingsChangedListener
 object MjmlRendererServiceUtils {
     fun isJavaScriptPluginAvailable(): Boolean {
         val jsPluginId = PluginId.getId("JavaScript")
-        val plugin = PluginManagerCore.getPlugin(jsPluginId)
-        return plugin != null && !PluginManagerCore.isDisabled(jsPluginId)
+        // findEnabledPlugin returns the descriptor only when the plugin is both installed and enabled,
+        // so it covers the previous null + !isDisabled checks in a single public-API call.
+        return PluginManager.getInstance().findEnabledPlugin(jsPluginId) != null
     }
 }
 

--- a/src/main/kotlin/de/timo_reymann/mjml_support/editor/rendering/NodeMjmlRenderer.kt
+++ b/src/main/kotlin/de/timo_reymann/mjml_support/editor/rendering/NodeMjmlRenderer.kt
@@ -1,11 +1,13 @@
 package de.timo_reymann.mjml_support.editor.rendering
 
-import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.process.OSProcessHandler
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.process.BaseProcessHandler
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessOutputType
-import com.intellij.javascript.nodejs.interpreter.NodeCommandLineConfigurator
+import com.intellij.javascript.nodejs.execution.NodeTargetRun
+import com.intellij.javascript.nodejs.execution.NodeTargetRunOptions
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterRef
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
@@ -19,7 +21,6 @@ import de.timo_reymann.mjml_support.settings.MjmlVersion
 import de.timo_reymann.mjml_support.util.FilePluginUtil
 import java.io.File
 import java.nio.charset.StandardCharsets
-import java.util.*
 
 class NodeMjmlRenderer(project: Project) : BaseMjmlRenderer(project) {
     private val nodeMajorVersionCache = mutableMapOf<String, Int?>()
@@ -33,69 +34,65 @@ class NodeMjmlRenderer(project: Project) : BaseMjmlRenderer(project) {
             project.basePath
         )
 
-        // One temp file per render. The renderer is project-scoped (single instance), so
-        // sharing a single file across concurrent renders from multiple editors caused one
-        // editor's preview to show another editor's HTML when their writes interleaved.
-        val tempFile = File.createTempFile("mjml-render-${UUID.randomUUID()}", ".json")
-        try {
-            objectMapper.writeValue(tempFile, mjmlRenderParameters)
-            val commandLine = generateCommandLine(virtualFile, tempFile)
-            commandLine ?: return renderError(
-                MjmlBundle.message("mjml_preview.node_not_configured"),
-                MjmlBundle.message("mjml_preview.unavailable")
-            )
+        // The render parameters are fed to the renderer process via stdin (the bundled JS reads
+        // fd 0). Each render starts its own process with its own stdin, so concurrent renders from
+        // multiple editors can no longer interleave onto a shared resource.
+        val paramsJson = objectMapper.writeValueAsString(mjmlRenderParameters)
+        val targetRun = createTargetRun(virtualFile) ?: return renderError(
+            MjmlBundle.message("mjml_preview.node_not_configured"),
+            MjmlBundle.message("mjml_preview.unavailable")
+        )
 
-            if (mjmlSettings.mjmlVersionEnum == MjmlVersion.V5) {
-                val versionError = checkNodeVersionForV5(virtualFile)
-                if (versionError != null) {
-                    return versionError
-                }
+        if (mjmlSettings.mjmlVersionEnum == MjmlVersion.V5) {
+            val versionError = checkNodeVersionForV5(virtualFile)
+            if (versionError != null) {
+                return versionError
             }
+        }
 
-            val rendererScript = getRendererScript()
-            commandLine.withParameters(rendererScript)
+        val rendererScript = getRendererScript()
+        targetRun.commandLineBuilder.addParameter(targetRun.path(rendererScript))
 
-            getLogger<NodeMjmlRenderer>().info {
-                val selected = mjmlSettings.mjmlVersionEnum
-                val bundled = BuiltinRenderResourceProvider.getBundledMjmlVersion(selected)
-                val origin = if (mjmlSettings.useBuiltInNodeRenderer) "bundled" else "custom"
-                "Rendering ${virtualFile.name} with MJML ${selected.id} ($origin, mjml=$bundled, script=$rendererScript)"
-            }
+        getLogger<NodeMjmlRenderer>().info {
+            val selected = mjmlSettings.mjmlVersionEnum
+            val bundled = BuiltinRenderResourceProvider.getBundledMjmlVersion(selected)
+            val origin = if (mjmlSettings.useBuiltInNodeRenderer) "bundled" else "custom"
+            "Rendering ${virtualFile.name} with MJML ${selected.id} ($origin, mjml=$bundled, script=$rendererScript)"
+        }
 
-            val (exitCode, output) = captureOutput(commandLine)
+        val (exitCode, output) = captureOutput(targetRun, paramsJson)
 
-            if (exitCode != 0) {
-                if (!File(rendererScript).exists()) {
-                    return renderError(
-                        MjmlBundle.message(if (mjmlSettings.useBuiltInNodeRenderer) "mjml_preview.renderer_copying" else "mjml_preview.renderer_missing"),
-                        "<pre>${MjmlBundle.message("mjml_preview.renderer_preview_will_reload")}</pre>"
-                    )
-                }
-
+        if (exitCode != 0) {
+            if (!File(rendererScript).exists()) {
                 return renderError(
-                    MjmlBundle.message("mjml_preview.render_failed"),
-                    "<pre>$output</pre>"
+                    MjmlBundle.message(if (mjmlSettings.useBuiltInNodeRenderer) "mjml_preview.renderer_copying" else "mjml_preview.renderer_missing"),
+                    "<pre>${MjmlBundle.message("mjml_preview.renderer_preview_will_reload")}</pre>"
                 )
             }
-            return output
-        } finally {
-            tempFile.delete()
+
+            return renderError(
+                MjmlBundle.message("mjml_preview.render_failed"),
+                "<pre>$output</pre>"
+            )
+        }
+        return output
+    }
+
+    private fun createTargetRun(virtualFile: VirtualFile): NodeTargetRun? {
+        val nodeJsInterpreter = NodeJsInterpreterRef.createProjectRef().resolve(project) ?: return null
+        return try {
+            val targetRun = NodeTargetRun(nodeJsInterpreter, project, null, NodeTargetRunOptions.of(false))
+            targetRun.commandLineBuilder.charset = StandardCharsets.UTF_8
+            targetRun.commandLineBuilder.setWorkingDirectory(virtualFile.parent.toNioPath().toString())
+            targetRun
+        } catch (e: ExecutionException) {
+            getLogger<NodeMjmlRenderer>().warn { "Failed to set up node process: ${e.message}" }
+            null
         }
     }
 
-    private fun generateCommandLine(virtualFile: VirtualFile, inputFile: File): GeneralCommandLine? {
-        val nodeJsInterpreter = NodeJsInterpreterRef.createProjectRef().resolve(project) ?: return null
-        val commandLine = GeneralCommandLine("node")
-            .withInput(inputFile)
-            .withCharset(StandardCharsets.UTF_8)
-            .withWorkDirectory(virtualFile.parent.toNioPath().toFile())
-        val commandLineConfigurator = NodeCommandLineConfigurator.find(nodeJsInterpreter)
-        commandLineConfigurator.configure(commandLine)
-        return commandLine
-    }
-
-    private fun captureOutput(commandLine: GeneralCommandLine): Pair<Int, String> {
-        val processHandler = OSProcessHandler(commandLine)
+    private fun captureOutput(targetRun: NodeTargetRun, input: String?): Pair<Int, String> {
+        val processHandler = targetRun.startProcess()
         val buffer = StringBuffer()
         processHandler.addProcessListener(object : ProcessListener {
             override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
@@ -117,8 +114,21 @@ class NodeMjmlRenderer(project: Project) : BaseMjmlRenderer(project) {
         })
 
         processHandler.startNotify()
+        // Feed the render parameters via stdin only after output draining has started, so a chatty
+        // process can never fill the stdout pipe and deadlock while we are still writing.
+        if (input != null) {
+            writeToStdin(processHandler, input)
+        }
         processHandler.waitFor()
         return Pair(processHandler.exitCode!!, buffer.toString())
+    }
+
+    private fun writeToStdin(processHandler: ProcessHandler, input: String) {
+        val stdin = (processHandler as? BaseProcessHandler<*>)?.processInput ?: return
+        stdin.use {
+            it.write(input.toByteArray(StandardCharsets.UTF_8))
+            it.flush()
+        }
     }
 
     private fun getRendererScript(): String {
@@ -143,14 +153,10 @@ class NodeMjmlRenderer(project: Project) : BaseMjmlRenderer(project) {
     }
 
     private fun detectNodeMajorVersion(virtualFile: VirtualFile): Int? {
-        val nodeJsInterpreter = NodeJsInterpreterRef.createProjectRef().resolve(project) ?: return null
-        val cmd = GeneralCommandLine("node")
-            .withCharset(StandardCharsets.UTF_8)
-            .withWorkDirectory(virtualFile.parent.toNioPath().toFile())
-        NodeCommandLineConfigurator.find(nodeJsInterpreter).configure(cmd)
-        cmd.withParameters("--version")
+        val targetRun = createTargetRun(virtualFile) ?: return null
+        targetRun.commandLineBuilder.addParameter("--version")
 
-        val (exitCode, output) = captureOutput(cmd)
+        val (exitCode, output) = captureOutput(targetRun, null)
         if (exitCode != 0) return null
         // Output is like "v22.5.1\n"
         val trimmed = output.trim().removePrefix("v")

--- a/src/main/kotlin/de/timo_reymann/mjml_support/editor/ui/MjmlPreviewFileEditor.kt
+++ b/src/main/kotlin/de/timo_reymann/mjml_support/editor/ui/MjmlPreviewFileEditor.kt
@@ -5,7 +5,6 @@ import com.intellij.codeHighlighting.BackgroundEditorHighlighter
 import com.intellij.ide.highlighter.HtmlFileType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
@@ -161,10 +160,10 @@ class MjmlPreviewFileEditor(private val project: Project, private val virtualFil
         var hasRoot = false
         var hasBody = false
         var tags: Collection<XmlTag>? = null
-        ReadAction.run<Exception> {
+        ApplicationManager.getApplication().runReadAction {
             val psi = PsiManager.getInstance(project)
                 .findFile(virtualFile)
-            psi ?: return@run
+                ?: return@runReadAction
             tags = PsiTreeUtil.findChildrenOfType(psi, XmlTag::class.java)
         }
 
@@ -224,7 +223,7 @@ class MjmlPreviewFileEditor(private val project: Project, private val virtualFil
         if (DumbService.isDumb(project)) {
             includes = listOf()
         } else {
-            ReadAction.run<Exception> {
+            ApplicationManager.getApplication().runReadAction {
                 includes = getFilesWithIncludesFor(virtualFile, project)
             }
         }

--- a/src/main/kotlin/de/timo_reymann/mjml_support/settings/MjmlSettings.kt
+++ b/src/main/kotlin/de/timo_reymann/mjml_support/settings/MjmlSettings.kt
@@ -8,7 +8,7 @@ enum class MjmlVersion(val id: String, val dirName: String) {
     V5("v5", "renderer-v5");
 
     companion object {
-        fun fromId(id: String): MjmlVersion = entries.firstOrNull { it.id == id } ?: V4
+        fun fromId(id: String): MjmlVersion = entries.firstOrNull { it.id == id } ?: V5
     }
 }
 
@@ -18,7 +18,7 @@ class MjmlSettings : PersistentStateComponent<MjmlSettings>, BaseState() {
     var renderScriptPath: String by nonNullString(BUILT_IN)
     var rendererWASIPath: String by nonNullString(BUILT_IN)
     var rendererBackend: String by nonNullString("node")
-    var mjmlVersion: String by nonNullString(MjmlVersion.V4.id)
+    var mjmlVersion: String by nonNullString(MjmlVersion.V5.id)
     val useBuiltInNodeRenderer: Boolean
         get() = renderScriptPath == BUILT_IN || renderScriptPath.isBlank()
     val useBuiltinWASIRenderer: Boolean

--- a/src/main/kotlin/de/timo_reymann/mjml_support/tagprovider/custom/JSES6ComponentMjmlTagInformationProvider.kt
+++ b/src/main/kotlin/de/timo_reymann/mjml_support/tagprovider/custom/JSES6ComponentMjmlTagInformationProvider.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
+import com.intellij.psi.stubs.StubIndexExtension
 import com.intellij.util.CommonProcessors
 import de.timo_reymann.mjml_support.api.MjmlTagInformation
 import de.timo_reymann.mjml_support.api.MjmlTagInformationProvider
@@ -40,7 +41,7 @@ class JSES6ComponentMjmlTagInformationProvider : MjmlTagInformationProvider() {
         val list = ArrayList<PsiElement>()
         StubIndex.getInstance()
             .processElements(
-                JSSuperClassIndex.KEY,
+                superClassIndexKey,
                 "BodyComponent",
                 project,
                 GlobalSearchScope.allScope(project),
@@ -63,4 +64,12 @@ class JSES6ComponentMjmlTagInformationProvider : MjmlTagInformationProvider() {
     }
 
     override fun getPriority() = 99
+
+    private companion object {
+        // Resolve the stub index key from the registered extension instead of the deprecated
+        // JSSuperClassIndex.KEY static field.
+        private val superClassIndexKey by lazy {
+            StubIndexExtension.EP_NAME.findExtensionOrFail(JSSuperClassIndex::class.java).key
+        }
+    }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,6 +41,18 @@
     <!-- language=html -->
     <change-notes><![CDATA[
         <ul>
+            <li>5.7.0
+                <ul>
+                    <li>The bundled MJML version now defaults to <b>v5</b> (was v4)
+                        <ul>
+                            <li>Projects using v4 &mdash; including those on the previous default &mdash; switch to v5 after updating. Note that v5 produces different HTML (new minifier, mj-body driven body tag) and requires Node.js 20 or newer</li>
+                            <li>To keep the old output, select v4 again under <b>Settings &gt; Tools &gt; MJML Settings &gt; Bundled MJML version</b>; v4 stays available in legacy/maintenance mode</li>
+                        </ul>
+                    </li>
+                    <li>Faster side-by-side preview: render parameters are now streamed to the Node renderer over stdin instead of being written to a temporary file on every render, removing per-keystroke temp-file disk I/O from the preview update path</li>
+                    <li>Updated to current IntelliJ Platform APIs for forward compatibility with newer IDE versions (no functional change)</li>
+                </ul>
+            </li>
             <li>5.6.0
                 <ul>
                     <li>Bundle MJML v5 alongside v4 (<a

--- a/src/main/resources/messages/MjmlBundle.properties
+++ b/src/main/resources/messages/MjmlBundle.properties
@@ -60,10 +60,10 @@ settings.config_file.help=Path or directory of .mjmlconfig file (leave blank for
 settings.node_script.text=Node.js script
 settings.node_script.help=Bundled script uses the MJML version selected below. For more information click <a href="https://plugins.jetbrains.com/plugin/16418-mjml-support/tutorials/custom-rendering-script#nodejs">here</a>.
 settings.mjml_version.text=Bundled MJML version
-settings.mjml_version.v4.text=MJML v{0} (default, maintenance mode)
-settings.mjml_version.v4.help=Stable, recommended for existing projects. Will receive critical fixes only and be retired in a future major plugin release.
-settings.mjml_version.v5.text=MJML v{0} (opt-in)
-settings.mjml_version.v5.help=Requires Node.js 20+ and changes the generated HTML (more aggressive minification, mj-body driven body tag). mj-include is automatically wired to the file directory. See <a href="https://github.com/mjmlio/mjml/releases/tag/v5.0.0">MJML 5 release notes</a>.
+settings.mjml_version.v4.text=MJML v{0} (legacy, maintenance mode)
+settings.mjml_version.v4.help=Kept for existing projects that depend on the v4 output. Receives critical fixes only and will be retired in a future major plugin release.
+settings.mjml_version.v5.text=MJML v{0} (default)
+settings.mjml_version.v5.help=Default for new projects. Requires Node.js 20+ and changes the generated HTML (more aggressive minification, mj-body driven body tag). mj-include is automatically wired to the file directory. See <a href="https://github.com/mjmlio/mjml/releases/tag/v5.0.0">MJML 5 release notes</a>.
 settings.wasi_binary.text=WASI binary
 setting.wasi_binary.help=Bundled WASI uses MRML {0}, For more information click <a href="https://plugins.jetbrains.com/plugin/16418-mjml-support/tutorials/custom-rendering-script#wasi">here</a>.
 settings.render_backend_select.text=Renderer backend to use


### PR DESCRIPTION
## Summary

Two related commits:

### 1. Resolve IntelliJ Plugin Verifier findings (`fix:`)
Addresses the internal / deprecated / experimental API usages reported against 5.6.0:

| Finding | Resolution |
|---|---|
| **internal** `PluginManagerCore.getPlugin(PluginId)` | Public `PluginManager.getInstance().findEnabledPlugin(...)` (covers installed + enabled in one call) |
| **deprecated** `ReadAction.run(ThrowableRunnable)` ×2 | `ApplicationManager.getApplication().runReadAction { }` |
| **deprecated** `JSSuperClassIndex.KEY` | Resolve the stub index key from the registered `StubIndexExtension` (the `getInstance()` replacement doesn't exist in the 2025.1 compile target) |
| **experimental** `AsyncFileEditorProvider.createFileEditor(...)` ×2 | Drop `AsyncFileEditorProvider` for plain `FileEditorProvider` — editors were already built synchronously, so the async/`Builder` path added no value |
| **deprecated class** `NodeCommandLineConfigurator` ×2 | Migrate to the `NodeTargetRun` Targets API; render params are piped via process **stdin** instead of a shared temp file (bundled JS contract unchanged) |

### 2. Default bundled MJML version to v5 (`feat:`)
- Default `mjmlVersion` (and the `fromId` fallback) now resolve to **v5**; v4 stays selectable in legacy/maintenance mode.
- Settings UI relabels v5 as default / v4 as legacy, with updated help text.
- `plugin.xml` gains a **5.7.0** change-notes entry.

> ⚠️ Behaviour change: projects on v4 (including via the previous implicit default) move to v5 after updating. v5 produces different HTML and needs Node.js 20+. The changelog documents how to switch back.

## Performance
The side-by-side preview re-renders on (debounced) every keystroke. The renderer no longer creates/writes/deletes a temp file per render — params are streamed over stdin in-memory — removing per-keystroke filesystem I/O from the preview update path.

## Testing
- `./gradlew compileKotlin` clean
- `./gradlew test` — all 50 tests pass (incl. the JS component index resolution covering the `JSSuperClassIndex.KEY` change)

⚠️ The live `NodeTargetRun` process path can't be exercised in CI here; a manual smoke-test of the node-backed preview (bundled v4/v5 + a custom render script) is recommended before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)